### PR TITLE
Add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ChatGPT-Plus 是使用官方 ChatGPT API 的应用程序。
 [简体中文](./README.md) | [English](./README_en.md)
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/zhpd/chatgpt-plus)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=zhpd/chatgpt-plus&type=static&buildCmd=npm+run+build&outputDir=dist)
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/zhpd/chatgpt-plus)
 
@@ -244,6 +245,7 @@ npm run dev
 #### Vercel环境变量
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/zhpd/chatgpt-plus)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=zhpd/chatgpt-plus&type=static&buildCmd=npm+run+build&outputDir=dist)
 
 ### 手动打包
 


### PR DESCRIPTION
<img src="https://pandastack.io/logo.png" alt="PandaStack" height="40"/>

## Add Deploy to PandaStack button

This PR adds a **[Deploy to PandaStack](https://pandastack.io)** button alongside the existing Vercel button.

**[PandaStack](https://pandastack.io)** is a cloud deployment platform — supports static sites, containerized apps, databases, cronjobs, and more. A great alternative hosting option for your users.

### What this adds
```
[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=zhpd/chatgpt-plus)
```

Happy to adjust build settings or output directory if needed. Feel free to close if you'd prefer to keep one button. 🙂